### PR TITLE
use redux to control displayed noun. add correct settle functionality

### DIFF
--- a/packages/nouns-webapp/src/components/Auction/index.tsx
+++ b/packages/nouns-webapp/src/components/Auction/index.tsx
@@ -4,16 +4,16 @@ import { Row, Container } from 'react-bootstrap';
 import { LoadingNoun } from '../Noun';
 import { Auction as IAuction } from '../../wrappers/nounsAuction';
 import classes from './Auction.module.css';
-import { useEffect, useState } from 'react';
 import { INounSeed } from '../../wrappers/nounToken';
 import { isNounderNoun } from '../../utils/nounderNoun';
 import NounderNounContent from '../NounderNounContent';
-import { ApolloError } from '@apollo/client';
-import { useQuery } from '@apollo/client';
-import { auctionQuery } from '../../wrappers/subgraph';
-import { BigNumber } from 'ethers';
 import AuctionActivity from '../AuctionActivity';
 import { useHistory } from 'react-router-dom';
+import { useAppDispatch, useAppSelector } from '../../hooks';
+import {
+  setNextOnDisplayAuctionNounId,
+  setPrevOnDisplayAuctionNounId,
+} from '../../state/slices/onDisplayAuction';
 /* OLD IMPORTS - FLAGGED FOR DELETION */
 // import {
 //   setNextOnDisplayAuctionNounId,
@@ -22,100 +22,117 @@ import { useHistory } from 'react-router-dom';
 // import { useHistory } from 'react-router-dom';
 // import { useAppDispatch, useAppSelector } from '../../hooks';
 // import PartyActivity from '../PartyActivity';
+// import { useQuery } from '@apollo/client';
+// import { auctionQuery } from '../../wrappers/subgraph';
+// import { useEffect, useState } from 'react';
+// import { ApolloError } from '@apollo/client';
+// import { BigNumber } from 'ethers';
 
-const prevAuctionsAvailable = (
-  loadingPrev: boolean,
-  errorPrev: ApolloError | undefined,
-  prevAuction: IAuction,
-) => {
-  return !loadingPrev && prevAuction !== undefined && !errorPrev;
-};
+// const prevAuctionsAvailable = (
+//   loadingPrev: boolean,
+//   errorPrev: ApolloError | undefined,
+//   prevAuction: IAuction,
+// ) => {
+//   return !loadingPrev && prevAuction !== undefined && !errorPrev;
+// };
 
-const createAuctionObj = (data: any): IAuction => {
-  const auction: IAuction = {
-    amount: BigNumber.from(data.auction.amount),
-    bidder: data.auction?.bidder?.id,
-    endTime: data.auction.endTime,
-    startTime: data.auction.startTime,
-    // length: data.auction.endTime - data.auction.startTime,
-    nounId: data.auction.id,
-    settled: data.auction.settled,
-  };
-  return auction;
-};
+// const createAuctionObj = (data: any): IAuction => {
+//   const auction: IAuction = {
+//     amount: BigNumber.from(data.auction.amount),
+//     bidder: data.auction?.bidder?.id,
+//     endTime: data.auction.endTime,
+//     startTime: data.auction.startTime,
+//     // length: data.auction.endTime - data.auction.startTime,
+//     nounId: data.auction.id,
+//     settled: data.auction.settled,
+//   };
+//   return auction;
+// };
 
 const Auction: React.FC<{ auction: IAuction; bgColorHandler: (useGrey: boolean) => void }> =
   props => {
     const { auction: currentAuction, bgColorHandler } = props;
     const history = useHistory();
-    const [onDisplayNounId, setOnDisplayNounId] = useState(currentAuction && currentAuction.nounId);
-    const [lastAuctionId, setLastAuctionId] = useState(currentAuction && currentAuction.nounId);
-    const [isLastAuction, setIsLastAuction] = useState(true);
-    const [isFirstAuction, setIsFirstAuction] = useState(false);
+    const dispatch = useAppDispatch();
+    const lastNounId = useAppSelector(state => state.onDisplayAuction.lastAuctionNounId);
 
-    // Query onDisplayNounId auction. Used to display past auctions' data.
-    const { data: dataCurrent } = useQuery(
-      auctionQuery(onDisplayNounId && onDisplayNounId.toNumber()),
-    );
-    // Query onDisplayNounId auction plus one. Used to determine nounder noun timestamp.
-    const { data: dataNext } = useQuery(
-      auctionQuery(onDisplayNounId && onDisplayNounId.add(1).toNumber()),
-    );
+    // const [onDisplayNounId, setOnDisplayNounId] = useState(currentAuction && currentAuction.nounId);
+    // const [lastAuctionId, setLastAuctionId] = useState(currentAuction && currentAuction.nounId);
+    // const [isLastAuction, setIsLastAuction] = useState(true);
+    // const [isFirstAuction, setIsFirstAuction] = useState(false);
+
+    // // Query onDisplayNounId auction. Used to display past auctions' data.
+    // const { data: dataCurrent } = useQuery(
+    //   auctionQuery(onDisplayNounId && onDisplayNounId.toNumber()),
+    // );
+    // // Query onDisplayNounId auction plus one. Used to determine nounder noun timestamp.
+    // const { data: dataNext } = useQuery(
+    //   auctionQuery(onDisplayNounId && onDisplayNounId.add(1).toNumber()),
+    // );
 
     // Query onDisplayNounId auction minus one. Used to cache prev auction + check if The Graph queries are functional.
-    const {
-      loading: loadingPrev,
-      data: dataPrev,
-      error: errorPrev,
-    } = useQuery(auctionQuery(onDisplayNounId && onDisplayNounId.sub(1).toNumber()), {
-      pollInterval: 10000,
-    });
+    // const {
+    //   loading: loadingPrev,
+    //   data: dataPrev,
+    //   error: errorPrev,
+    // } = useQuery(auctionQuery(onDisplayNounId && onDisplayNounId.sub(1).toNumber()), {
+    //   pollInterval: 10000,
+    // });
 
     /**
      * Auction derived from `onDisplayNounId` query
      */
-    const auction: IAuction = dataCurrent && dataCurrent.auction && createAuctionObj(dataCurrent);
+    // const auction: IAuction = dataCurrent && dataCurrent.auction && createAuctionObj(dataCurrent);
     /**
      * Auction derived from `onDisplayNounId.add(1)` query
      */
-    const nextAuction: IAuction = dataNext && dataNext.auction && createAuctionObj(dataNext);
+    // const nextAuction: IAuction = dataNext && dataNext.auction && createAuctionObj(dataNext);
     /**
      * Auction derived from `onDisplayNounId.sub(1)` query
      */
-    const prevAuction: IAuction = dataPrev && dataPrev.auction && createAuctionObj(dataPrev);
+    // const prevAuction: IAuction = dataPrev && dataPrev.auction && createAuctionObj(dataPrev);
 
     const loadedNounHandler = (seed: INounSeed) => {
       bgColorHandler(seed.background === 0);
     };
 
-    useEffect(() => {
-      if (!onDisplayNounId || (currentAuction && currentAuction.nounId.gt(lastAuctionId))) {
-        setOnDisplayNounId(currentAuction && currentAuction.nounId);
-        setLastAuctionId(currentAuction && currentAuction.nounId);
-      }
-    }, [onDisplayNounId, currentAuction, lastAuctionId]);
+    // useEffect(() => {
+    //   if (!onDisplayNounId || (currentAuction && currentAuction.nounId.gt(lastAuctionId))) {
+    //     setOnDisplayNounId(currentAuction && currentAuction.nounId);
+    //     setLastAuctionId(currentAuction && currentAuction.nounId);
+    //   }
+    // }, [onDisplayNounId, currentAuction, lastAuctionId]);
 
-    const auctionHandlerFactory = (nounIdMutator: (prev: BigNumber) => BigNumber) => () => {
-      setOnDisplayNounId(prev => {
-        const updatedNounId = nounIdMutator(prev);
-        setIsFirstAuction(updatedNounId.eq(0) ? true : false);
-        setIsLastAuction(updatedNounId.eq(currentAuction && currentAuction.nounId) ? true : false);
-        return updatedNounId;
-      });
+    // const auctionHandlerFactory = (nounIdMutator: (prev: BigNumber) => BigNumber) => () => {
+    //   setOnDisplayNounId(prev => {
+    //     const updatedNounId = nounIdMutator(prev);
+    //     setIsFirstAuction(updatedNounId.eq(0) ? true : false);
+    //     setIsLastAuction(updatedNounId.eq(currentAuction && currentAuction.nounId) ? true : false);
+    //     return updatedNounId;
+    //   });
+    // };
+
+    // const prevAuctionHandler = auctionHandlerFactory((prev: BigNumber) => {
+    //   history.push(`/noun/${prev.sub(1)}`);
+    //   return prev.sub(1);
+    // });
+    // const nextAuctionHandler = auctionHandlerFactory((prev: BigNumber) => {
+    //   history.push(`/noun/${prev.add(1)}`);
+    //   return prev.add(1);
+    // });
+
+    const prevAuctionHandler = () => {
+      dispatch(setPrevOnDisplayAuctionNounId());
+      history.push(`/noun/${currentAuction.nounId.toNumber() - 1}`);
     };
-
-    const prevAuctionHandler = auctionHandlerFactory((prev: BigNumber) => {
-      history.push(`/noun/${prev.sub(1)}`);
-      return prev.sub(1);
-    });
-    const nextAuctionHandler = auctionHandlerFactory((prev: BigNumber) => {
-      history.push(`/noun/${prev.add(1)}`);
-      return prev.add(1);
-    });
+    const nextAuctionHandler = () => {
+      dispatch(setNextOnDisplayAuctionNounId());
+      history.push(`/noun/${currentAuction.nounId.toNumber() + 1}`);
+    };
 
     const nounContent = (
       <div className={classes.nounWrapper}>
-        <StandaloneNounWithSeed nounId={onDisplayNounId} onLoadSeed={loadedNounHandler} />
+        <StandaloneNounWithSeed nounId={currentAuction.nounId} onLoadSeed={loadedNounHandler} />
       </div>
     );
 
@@ -125,38 +142,48 @@ const Auction: React.FC<{ auction: IAuction; bgColorHandler: (useGrey: boolean) 
       </div>
     );
 
-    const auctionActivityContent = (auction: IAuction, displayGraphDepComps: boolean) => (
+    // const auctionActivityContent = (auction: IAuction, displayGraphDepComps: boolean) => (
+    //   <AuctionActivity
+    //     auction={currentAuction}
+    //     isFirstAuction={currentAuction.nounId.eq(0)}
+    //     isLastAuction={currentAuction.nounId.eq(lastNounId)}
+    //     onPrevAuctionClick={prevAuctionHandler}
+    //     onNextAuctionClick={nextAuctionHandler}
+    //     displayGraphDepComps={true}
+    //   />
+    // );
+
+    // const currentAuctionActivityContent =
+    //   currentAuction &&
+    //   auctionActivityContent(
+    //     currentAuction,
+    //     onDisplayNounId && prevAuctionsAvailable(loadingPrev, errorPrev, prevAuction), // else check if prev auct is avail
+    //   );
+
+    // const pastAuctionActivityContent =
+    //   auction &&
+    //   auctionActivityContent(auction, prevAuctionsAvailable(loadingPrev, errorPrev, prevAuction));
+
+    const currentAuctionActivityContent = lastNounId && (
       <AuctionActivity
-        auction={auction}
-        isFirstAuction={isFirstAuction}
-        isLastAuction={isLastAuction}
+        auction={currentAuction}
+        isFirstAuction={currentAuction.nounId.eq(0)}
+        isLastAuction={currentAuction.nounId.eq(lastNounId)}
         onPrevAuctionClick={prevAuctionHandler}
         onNextAuctionClick={nextAuctionHandler}
-        displayGraphDepComps={displayGraphDepComps}
+        displayGraphDepComps={true}
       />
     );
 
-    const currentAuctionActivityContent =
-      currentAuction &&
-      auctionActivityContent(
-        currentAuction,
-        onDisplayNounId && prevAuctionsAvailable(loadingPrev, errorPrev, prevAuction), // else check if prev auct is avail
-      );
-
-    const pastAuctionActivityContent =
-      auction &&
-      auctionActivityContent(auction, prevAuctionsAvailable(loadingPrev, errorPrev, prevAuction));
-
-    // FLAGGED FOR DELETION - Will we ever need to show nounder's nouns?
-    const nounderNounContent = nextAuction && (
+    const nounderNounContent = lastNounId && (
       <NounderNounContent
         // mintTimestamp={nextAuction.startTime}
-        nounId={onDisplayNounId}
-        isFirstAuction={isFirstAuction}
-        isLastAuction={isLastAuction}
+        nounId={currentAuction.nounId}
+        isFirstAuction={currentAuction.nounId.eq(0)}
+        isLastAuction={currentAuction.nounId.eq(lastNounId)}
         onPrevAuctionClick={prevAuctionHandler}
         onNextAuctionClick={nextAuctionHandler}
-        displayGraphDepComps={prevAuctionsAvailable(loadingPrev, errorPrev, prevAuction)}
+        displayGraphDepComps={true}
       />
     );
 
@@ -164,21 +191,12 @@ const Auction: React.FC<{ auction: IAuction; bgColorHandler: (useGrey: boolean) 
       <Container fluid="lg" className={classes.pageContentWrapper}>
         <Row>
           <Col lg={{ span: 6 }} className={`align-self-end ${classes.noPaddingMargin}`}>
-            {onDisplayNounId ? nounContent : loadingNoun}
+            {currentAuction ? nounContent : loadingNoun}
           </Col>
-          <Col
-            lg={{ span: 6 }}
-            className={
-              isLastAuction
-                ? classes.currentAuctionActivityContainer
-                : classes.pastAuctionActivityContainer
-            }
-          >
-            {onDisplayNounId && isNounderNoun(onDisplayNounId)
+          <Col lg={{ span: 6 }} className={classes.currentAuctionActivityContainer}>
+            {currentAuction.nounId && isNounderNoun(currentAuction.nounId)
               ? nounderNounContent
-              : isLastAuction
-              ? currentAuctionActivityContent
-              : pastAuctionActivityContent}
+              : currentAuctionActivityContent}
           </Col>
           <Col lg={2} />
         </Row>

--- a/packages/nouns-webapp/src/components/AuctionActivity/index.tsx
+++ b/packages/nouns-webapp/src/components/AuctionActivity/index.tsx
@@ -59,11 +59,8 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
     displayGraphDepComps,
   } = props;
 
-  const { auction: currentAuction } = props;
   const [auctionEnded, setAuctionEnded] = useState(false);
   const [auctionTimer, setAuctionTimer] = useState(false);
-
-
 
   // const [showBidHistoryModal, setShowBidHistoryModal] = useState(false);
   // const showBidModalHandler = () => {
@@ -151,8 +148,8 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
               )}
             </Col>
           </Row>
-          {/* TO DO - ADD IN LOGIC TO CHECK IF SETTLED ALREADY */}
-          {!isLastAuction && (
+
+          {!isLastAuction && auction && auction.nounId && (
             <Row className={classes.buttonsWrapper}>
               <Col>
                 <SettleAuction auction={auction} />
@@ -161,8 +158,8 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
           )}
           {isLastAuction && (
             <>
-              <PartyVault auction={currentAuction} />
-              <PartyButtons />
+              <PartyVault auction={auction} />
+              <PartyButtons auction={auction} />
               <PartyGuestList />
             </>
           )}

--- a/packages/nouns-webapp/src/components/ConnectWalletButton/index.tsx
+++ b/packages/nouns-webapp/src/components/ConnectWalletButton/index.tsx
@@ -5,11 +5,12 @@ import WalletConnectModal from '../WalletConnectModal';
 import AddFundsModal from '../AddFundsModal';
 import { Col, Row } from 'react-bootstrap';
 import Bid from '../Bid';
-import { useAuction } from '../../wrappers/nounsAuction';
-import config from '../../config';
 import SettleAuction from '../SettleAuction';
-
+import { Auction } from '../../wrappers/nounsAuction';
 /*  Currently unused packages FLAGGED FOR DELETION */
+// import { usePendingSettled } from '../../wrappers/nounsParty';
+// import { useAuction } from '../../wrappers/nounsAuction';
+// import config from '../../config';
 // import logo from '../../assets/logo.svg';
 // import { useEtherBalance, useEthers } from '@usedapp/core';
 // import { Link } from 'react-router-dom';
@@ -18,7 +19,10 @@ import SettleAuction from '../SettleAuction';
 // import { utils } from 'ethers';
 // import { buildEtherscanAddressLink, Network } from '../../utils/buildEtherscanLink';
 
-const ConnectWalletButton = () => {
+const ConnectWalletButton: React.FC<{
+  auction: Auction;
+}> = props => {
+  const { auction: currentAuction } = props;
   const activeAccount = useAppSelector(state => state.account.activeAccount);
   const [showConnectModal, setShowConnectModal] = useState(false);
   const [showFundsModal, setShowFundsModal] = useState(false);
@@ -26,7 +30,7 @@ const ConnectWalletButton = () => {
   const [auctionEnded, setAuctionEnded] = useState(false);
   const [auctionTimer, setAuctionTimer] = useState(false);
   const lastNounId = useAppSelector(state => state.onDisplayAuction.lastAuctionNounId);
-  const auction = useAuction(config.auctionProxyAddress);
+  // const auction = useAuction(config.auctionProxyAddress);
 
   const showModalHandler = () => {
     setShowConnectModal(true);
@@ -52,11 +56,11 @@ const ConnectWalletButton = () => {
 
   // timer logic
   useEffect(() => {
-    if (!auction) return;
+    if (!currentAuction) return;
 
-    const timeLeft = Number(auction.endTime) - Math.floor(Date.now() / 1000);
+    const timeLeft = Number(currentAuction.endTime) - Math.floor(Date.now() / 1000);
 
-    if (auction && timeLeft <= 0) {
+    if (currentAuction && timeLeft <= 0) {
       setAuctionEnded(true);
     } else {
       setAuctionEnded(false);
@@ -68,14 +72,13 @@ const ConnectWalletButton = () => {
         clearTimeout(timer);
       };
     }
-  }, [auctionTimer, auction]);
+  }, [auctionTimer, currentAuction]);
 
   const connectedContent = (
     <>
-    {/* TO DO - ADD IN LOGIC TO CHECK IF SETTLED ALREADY  */}
       {auctionEnded ? (
         <>
-          <SettleAuction auction={auction} />
+          <SettleAuction auction={currentAuction} />
         </>
       ) : (
         <Row>
@@ -129,14 +132,14 @@ const ConnectWalletButton = () => {
       {showFundsModal && activeAccount && (
         <AddFundsModal onDismiss={hideFundsModalHandler} activeAccount={activeAccount} />
       )}
-      {auction &&
+      {currentAuction &&
         lastNounId &&
-        auction?.nounId?.eq(lastNounId) &&
+        currentAuction?.nounId?.eq(lastNounId) &&
         showPlaceBidModal &&
         activeAccount &&
         !auctionEnded && (
           <Bid
-            auction={auction}
+            auction={currentAuction}
             auctionEnded={auctionEnded}
             hidePlaceBidModalHandler={hidePlaceBidModalHandler}
           />

--- a/packages/nouns-webapp/src/components/PartyActivity/index.tsx
+++ b/packages/nouns-webapp/src/components/PartyActivity/index.tsx
@@ -63,7 +63,7 @@ const PartyActivity: React.FC<{
   /**
    * Auction derived from `onDisplayNounId` query
    */
-  const auction: IAuction = dataCurrent && dataCurrent.auction && createAuctionObj(dataCurrent);
+  // const auction: IAuction = dataCurrent && dataCurrent.auction && createAuctionObj(dataCurrent);
   /**
    * Auction derived from `onDisplayNounId.add(1)` query
    */
@@ -138,7 +138,7 @@ const PartyActivity: React.FC<{
       {isLastAuction ? (
         <>
           <PartyVault auction={currentAuction} />
-          <PartyButtons />
+          <PartyButtons auction={currentAuction} />
           <PartyGuestList />
         </>
       ) : null}

--- a/packages/nouns-webapp/src/components/PartyButtons/index.tsx
+++ b/packages/nouns-webapp/src/components/PartyButtons/index.tsx
@@ -2,14 +2,18 @@ import React from 'react';
 import { Col, Row } from 'react-bootstrap';
 import ConnectWalletButton from '../ConnectWalletButton';
 import classes from './PartyButtons.module.css';
+import { Auction } from '../../wrappers/nounsAuction';
 
 // TODO
 // What is the party invite? Assume it's a link to the website? Will it just copy the website address?
-const PartyButtons = () => {
+const PartyButtons: React.FC<{
+  auction: Auction;
+}> = props => {
+  const { auction: currentAuction } = props;
   return (
     <Row className={classes.buttonsWrapper}>
       <Col>
-        <ConnectWalletButton />
+        <ConnectWalletButton auction={currentAuction} />
       </Col>
       {/* <Col className={classes.noRightPadding}>
         <button className={classes.invitePartyButton}>Send Party Invite!</button>

--- a/packages/nouns-webapp/src/config.ts
+++ b/packages/nouns-webapp/src/config.ts
@@ -33,7 +33,7 @@ const config: Record<SupportedChains, Config> = {
     nounsDaoProxyAddress: '0xd1C753D9A23eb5c57e0d023e993B9bd4F5086b04',
     nounsDaoExecutorAddress: '0xd1C753D9A23eb5c57e0d023e993B9bd4F5086b04',
     subgraphApiUri: 'https://api.thegraph.com/subgraphs/name/nounsdao/nouns-subgraph-rinkeby-v4',
-    enableHistory: process.env.REACT_APP_ENABLE_HISTORY === 'true' || false,
+    enableHistory: process.env.REACT_APP_ENABLE_HISTORY === 'true' || true,
     nounsPartyAddress: '0xd19b9Cfa463A729F6c3B6Df58D0c11DcFe72e63F',
   },
   [ChainId.Mainnet]: {
@@ -48,7 +48,7 @@ const config: Record<SupportedChains, Config> = {
     wsRpcUri:
       process.env.REACT_APP_MAINNET_WSRPC ||
       `wss://mainnet.infura.io/v3/${process.env.REACT_APP_INFURA_PROJECT_ID}`,
-    enableHistory: process.env.REACT_APP_ENABLE_HISTORY === 'true' || false,
+    enableHistory: process.env.REACT_APP_ENABLE_HISTORY === 'true' || true,
     nounsPartyAddress: 'TODO',
   },
   [LOCAL_CHAIN_ID]: {
@@ -59,7 +59,7 @@ const config: Record<SupportedChains, Config> = {
     nounsDaoProxyAddress: '0x610178dA211FEF7D417bC0e6FeD39F05609AD788',
     subgraphApiUri: '',
     jsonRpcUri: 'http://localhost:8545',
-    enableHistory: false,
+    enableHistory: true,
     wsRpcUri: 'ws://localhost:8545',
     nounsPartyAddress: 'TODO',
   },

--- a/packages/nouns-webapp/src/pages/Auction/index.tsx
+++ b/packages/nouns-webapp/src/pages/Auction/index.tsx
@@ -1,7 +1,5 @@
 import Auction from '../../components/Auction';
-import { useAuction } from '../../wrappers/nounsAuction';
 import { setUseGreyBackground } from '../../state/slices/application';
-import config from '../../config';
 import SocialCursorCollection from '../../components/SocialCursorCollection';
 import PageConfetti from '../../components/Confetti';
 import { useAppDispatch, useAppSelector } from '../../hooks';
@@ -10,10 +8,13 @@ import { push } from 'connected-react-router';
 import { nounPath } from '../../utils/history';
 import useOnDisplayAuction from '../../wrappers/onDisplayAuction';
 import { useEffect } from 'react';
-
-/* Currently unused packages flagged for removal */
 import Documentation from '../../components/Documentation';
 import Banner from '../../components/Banner';
+import HistoryCollection from '../../components/HistoryCollection';
+import { BigNumber } from 'ethers';
+/* Currently unused packages flagged for removal */
+// import config from '../../config';
+// import { useAuction } from '../../wrappers/nounsAuction';
 
 interface AuctionPageProps {
   initialAuctionId?: number;
@@ -23,7 +24,6 @@ const AuctionPage: React.FC<AuctionPageProps> = props => {
   const { initialAuctionId } = props;
   const onDisplayAuction = useOnDisplayAuction();
   const lastAuctionNounId = useAppSelector(state => state.onDisplayAuction.lastAuctionNounId);
-  const auction = useAuction(config.auctionProxyAddress);
 
   const dispatch = useAppDispatch();
 
@@ -53,11 +53,16 @@ const AuctionPage: React.FC<AuctionPageProps> = props => {
     <>
       <SocialCursorCollection />
       <PageConfetti />
-      <Auction
-        auction={auction}
-        bgColorHandler={(useGrey: boolean) => dispatch(setUseGreyBackground(useGrey))}
-      />
+      {onDisplayAuction && (
+        <Auction
+          auction={onDisplayAuction}
+          bgColorHandler={(useGrey: boolean) => dispatch(setUseGreyBackground(useGrey))}
+        />
+      )}
       <Banner />
+      {lastAuctionNounId && (
+        <HistoryCollection latestNounId={BigNumber.from(lastAuctionNounId)} historyCount={5} />
+      )}
       <Documentation />
     </>
   );


### PR DESCRIPTION
Implemented nouns history carousel, switched display noun and current auction to be handled in redux state, fixed URL functionality, fixed settle functionality to check if displayed noun has been settled.

TO DO:
- add message when user tries to placeBid if nouns party is the current winning bidder 
- hide party nouns auction settle button if nounsAuctionHouse has not settled the main auction yet

NOTES:
- in packages/nouns-webapp/src/pages/Auction/index.tsx, historyCount is currently set to 5. This value should and will be 10, but for testing purposes, it won't work if any of the past 10 auctions were not won, and there was not enough time to finish ten auctions. This is not a situation that should be possible normally