### PR TITLE
add history collection and prevent retries exhausted error

### DIFF
--- a/packages/nouns-webapp/src/pages/Auction/index.tsx
+++ b/packages/nouns-webapp/src/pages/Auction/index.tsx
@@ -9,8 +9,8 @@ import useOnDisplayAuction from '../../wrappers/onDisplayAuction';
 import { useEffect } from 'react';
 import Documentation from '../../components/Documentation';
 import Banner from '../../components/Banner';
-// import HistoryCollection from '../../components/HistoryCollection';
-// import { BigNumber } from 'ethers';
+import HistoryCollection from '../../components/HistoryCollection';
+import { BigNumber } from 'ethers';
 // import HistoryCollection from '../../components/HistoryCollection';
 /* Currently unused packages flagged for removal */
 // import config from '../../config';
@@ -59,9 +59,9 @@ const AuctionPage: React.FC<AuctionPageProps> = props => {
         />
       )}
       <Banner />
-      {/* {lastAuctionNounId && (
+      {lastAuctionNounId && (
         <HistoryCollection latestNounId={BigNumber.from(lastAuctionNounId)} historyCount={10} />
-      )} */}
+      )}
       <Documentation />
     </>
   );


### PR DESCRIPTION
add history collection. Check if noun was burned to prevent 'BlockReEmitMiddleware - retries exhausted' Metamask error resulting from repeated 'useNounToken' contract calls 